### PR TITLE
Inclui o serviço do MongoDB na rede docker measuresoftgram

### DIFF
--- a/installation/docker-compose.yml
+++ b/installation/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     container_name: measuresoftgram-db
     image: mongo
     restart: always
+    networks:
+      - measuresoftgram
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: example


### PR DESCRIPTION
## Descrição
Inclui o serviço do MongoDB na rede docker measuresoftgram.

## Porque este Pull Request é necessário?
Para que seja possível a comunicação entre o Service e o banco de dados (MongoDB).
