### PR TITLE
Adiciona documentos dos eventos Scrum

### DIFF
--- a/docs/scrum/sprint_1/retrospectiva.md
+++ b/docs/scrum/sprint_1/retrospectiva.md
@@ -1,0 +1,77 @@
+---
+title: Retrospectiva
+---
+
+# Retrospectiva da Sprint 1
+
+"A Retrospectiva da Sprint é uma oportunidade para o Time Scrum inspecionar a si próprio e criar um plano para melhorias a serem aplicadas na próxima Sprint." (SCHWABER e SUTHERLAND, 2014, p. 12).
+
+## Visão da sprint
+
+### Em relação às pessoas
+
+Como a sprint foi em relação às pessoas, não como membros do time Scrum, e sim como pessoas
+
+- Agitada
+- Apressada
+- Apertada
+- Cansativa
+- Satisfatória
+
+### Em relação aos relacionamentos
+
+Como a sprint foi em relação aos relacionamentos entre as pessoas
+
+- Maior interação entre a equipe
+- Os "super-pareamentos" se comunicaram bem
+- Troca de conhecimento
+
+### Em relação aos processos e ferramentas
+
+Como a sprint foi em relação aos processos e ferramentas
+
+- Ferramentas de Devops funcionando muito bem
+- GitFlow quase deu 100% certo
+- Conseguimos testar minimamente as funcionalidades desenvolvidas
+
+## Itens que foram bem (ordenados)
+
+Lista de itens que foram bem em ordem decrescente
+
+- Conseguimos realizar a entrega
+- Por algum milagre (ou não) os horários dos super-paramentos deram certo
+- Poucos problemas de ambiente
+- Time estava animado
+
+## Potenciais melhorias (ordenados)
+
+Lista de itens de potencial melhoria em ordem decrescente (maior prioridade para menor prioridade)
+
+- Desfazer os super-paramentos
+- Pensar em usar TDD
+- Melhor comunicação a cerca de discussões, PRs e etc
+
+## Como tornar o Scrum mais agradável
+
+Uma explicação melhor do Scrum ajudaria todo mundo a entender e participar melhor.
+
+## Como aumentar a qualidade do produto?
+
+Há algo que pode ser feito para aumentar a qualidade do produto?
+
+- Aumentar a quantidade de testes
+- Aumentar a diversidade de testes
+- Aumentar a qualidade dos testes
+- Refatorar os códigos
+- Remover códigos desnecessários (service e core)
+
+## Melhorias a serem implementadas no modo que o Time Scrum faz seu trabalho
+
+- Usar *pair programming* adequadamente
+- Comunicar os impedimentos e discussões no Discord
+
+"A implementação destas melhorias na próxima Sprint é a forma de adaptação à inspeção que o Time Scrum faz a si próprio." (SCHWABER e SUTHERLAND, 2014, p. 13).
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_1/revisao.md
+++ b/docs/scrum/sprint_1/revisao.md
@@ -1,0 +1,55 @@
+---
+title: Revisão
+---
+
+# Revisão da Sprint 1
+
+## O que ficou pronto nessa sprint?
+
+- Seleção das características, subcaracterísticas, medidas e pesos via CLI
+- Criação das funções de interpretação das medidas da característica de manutenibilidade
+- Leitura de métricas do arquivo JSON do Sonarcloud
+
+## Aspectos da sprint
+
+### Aspectos positivos
+
+- Início do desenvolvimento
+- Conseguimos finalizar o que foi planejado para a sprint
+- Aprendizado das ferramentas, tecnologias, metodologias e etc utilizados
+- Presença do time de EPS no desenvolvimento
+- O fluxo da atividade de criação da pré configuração do modelo ficou excelente
+
+### Problemas / soluções
+
+- Divergência aparente entre as fórmulas matemáticas das funções de interpretação no notebook e no PDF
+  - Conversar com o cliente
+- Prazo curto
+  - Maior dedicação
+- Docker deu pipoco na hora de comunicar os dois serviços
+  - Docker network is a miracle!
+- Bagunçamos a árvore do git
+  - Arrumamos a árvore do git (em partes), queria agradecer meu pai e minha mãe pelo uso de git rebase -i
+- Finalizar a release dentro do prazo
+  - Tentar se organizar melhor na próxima
+- O fluxo de atividades da criação da pré-config. não ficou tão bom
+  - Propusemos outro fluxo
+
+## O produto irá ser finalizado no prazo?
+
+- Ainda está cedo para esse tipo de análise, mesmo assim o time conseguiu entregar muita coisa nessa release, do 0 ao 100 bem rápido!
+
+## O que vem a seguir?
+
+- Criar as funções de interpretação das medidas de confiabilidade
+- Criar e persiste a pré configuração do modelo
+- Salvar as métricas extraídas do JSON do Sonar
+- Visualizar pré configuração do modelo
+
+## Mudanças no backlog de produto
+
+Não será necessária mudanças no backlog, apenas o fluxo normal de detalhamento das histórias.
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_2/planejamento.md
+++ b/docs/scrum/sprint_2/planejamento.md
@@ -1,0 +1,34 @@
+---
+title: Planejamento
+---
+
+# Planejamento da Sprint 2
+
+## Qual o objetivo da Sprint?
+
+### Objetivo visão TD
+
+Se familiarizar mais com as ferramentas, entregar mais funcionalidades "core" do MeasureSoftGram.
+
+## Definir os pares
+
+2 Pares e um trio
+
+- Vitor e Marcos
+- Lucas e Samuel
+- Joao, Jeff e Ana
+
+## Backlog da sprint
+
+- Criar funções de interpretação para a medida em4
+- Criar funções de interpretação para a medida em5
+- Criar funções de interpretação para a medida em6
+- Criar pré config do modelo
+- Visualizar pré config do modelo
+- Salvar as métricas
+- Implementar relacionamentos a partir da matriz de Haoues
+- Implementar operação de agregação
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_2/retrospectiva.md
+++ b/docs/scrum/sprint_2/retrospectiva.md
@@ -1,0 +1,62 @@
+---
+title: Retrospectiva
+---
+
+# Retrospectiva da Sprint 2
+
+"A Retrospectiva da Sprint é uma oportunidade para o Time Scrum inspecionar a si próprio e criar um plano para melhorias a serem aplicadas na próxima Sprint." (SCHWABER e SUTHERLAND, 2014, p. 12).
+
+## Visão da sprint
+
+### Em relação às pessoas
+
+- Difícil
+- Bagunçada no sentido da comunicação
+- Pouco transparente
+
+### Em relação aos relacionamentos
+
+- Maior interação entre a equipe
+- Troca de conhecimento
+
+### Em relação aos processos e ferramentas
+
+- Dificuldade com git
+- Deu certo a execução do notebook
+
+## Itens que foram bem (ordenados)
+
+- Mais habituados com a tecnologia
+- Equipe entendendo a arquitetura do sistema
+
+## Potenciais melhorias (ordenados)
+
+- Melhorar a comunicação entre a equipe, preferencialmente pelo Telegram
+  - Utilizar as marcações do telegram
+- Pedir ajuda quando necessário, mas pensar em desenvolver independência
+- Criar hábito de visitar os PRs com frequência no github
+- Criar PR como draft assim que começar o desenvovimento
+- Criar o hábito de atualizar o board do Zenhub com frequência
+- Mandar a daily com mais frequência e possivelmente com mais detalhes
+
+## Como tornar o Scrum mais agradável
+
+Uma explicação melhor do Scrum ajudaria todo mundo a entender e participar melhor.
+
+## Como aumentar a qualidade do produto?
+
+Há algo que pode ser feito para aumentar a qualidade do produto?
+
+- Se atentar ao padrão de código em python
+- Remover códigos desnecessários (service e core)
+
+## Melhorias a serem implementadas no modo que o Time Scrum faz seu trabalho
+
+- Comunicar os impedimentos e discussões no Discord
+- Abrir as Histórias de usuário
+
+"A implementação destas melhorias na próxima Sprint é a forma de adaptação à inspeção que o Time Scrum faz a si próprio." (SCHWABER e SUTHERLAND, 2014, p. 13).
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_2/revisao.md
+++ b/docs/scrum/sprint_2/revisao.md
@@ -1,0 +1,46 @@
+---
+title: Revisão
+---
+
+# Revisão da Sprint 2
+
+## O que ficou pronto nessa sprint?
+
+Nada
+
+## Aspectos da sprint
+
+### Aspectos positivos
+
+- Primeira semana de independência do time MDS
+- Primeira semana que desfizemos os superpareamentos
+- Conhecimento sobre outros componentes do projeto
+- Mais entendimento sobre o notebook de métricas
+
+### Problemas / soluções
+
+- Problema em reunir com o par ou trio
+  - Trabalhar assincronamente com o par ou trio
+- Agenda meio apertada para alguns pares
+  - Tentar se organizar melhor!
+- Entender o notebook foi difícil
+
+## O produto irá ser finalizado no prazo?
+
+- Ainda está cedo para esse tipo de análise
+
+## O que vem a seguir?
+
+- Criar as funções de interpretação das medidas de confiabilidade
+- Criar e persiste a pré configuração do modelo
+- Concluir a leitura das métricas
+- Visualizar a pré configuração do modelo
+- Testar a HU: "Implementar operação de ponderação"
+
+## Mudanças no backlog de produto
+
+Criar bug referente ao backspace nas entradas no CLI.
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_3/planejamento.md
+++ b/docs/scrum/sprint_3/planejamento.md
@@ -1,0 +1,28 @@
+---
+title: Planejamento
+---
+
+# Planejamento da Sprint 3
+
+## Qual o objetivo da Sprint?
+
+### Objetivo visão TD
+
+Entregar mais funcionalidades "core" do MeasureSoftGram. Algumas correções pontuais.
+
+## Definir os pares
+
+2 Pares e um trio
+
+- Vitor e Marcos
+- Lucas e Samuel
+- Joao, Jeff e Ana
+
+## Backlog da sprint
+
+- Criar o bug referente ao backspace
+- Detalhar: Visualizar a pré configuração do modelo
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_3/retrospectiva.md
+++ b/docs/scrum/sprint_3/retrospectiva.md
@@ -1,0 +1,63 @@
+---
+title: Retrospectiva
+---
+
+# Retrospectiva da Sprint 3
+
+"A Retrospectiva da Sprint é uma oportunidade para o Time Scrum inspecionar a si próprio e criar um plano para melhorias a serem aplicadas na próxima Sprint." (SCHWABER e SUTHERLAND, 2014, p. 12).
+
+## Visão da sprint
+
+### Em relação às pessoas
+
+- Difícil
+- Meio lenta
+- Melhorou no âmbito da comunicação
+
+### Em relação aos relacionamentos
+
+- O pessoal tem se ajudado, ex: Força tarefa do notebook
+
+### Em relação aos processos e ferramentas
+
+- Dificuldade com git
+- Dificuldade com banco de dados
+- Dificuldade com API (REST e MVC)
+- Dificuldade com o Docker
+- Melhorou a transparência em relação ao andamento das tarefas
+
+## Itens que foram bem (ordenados)
+
+- Pudemos ver que a parte matemática não é tão difícil, motivou o time
+- Equipe entendendo a arquitetura do sistema
+- Rápida reposta a pedidos de ajuda
+
+## Potenciais melhorias (ordenados)
+
+- Continuar abrindo PR Draft
+- Melhorar o jeito de mandar as dúvidas (don't ask to ask, just ask)
+- Criar o hábito de olhar os links de documentação
+
+## Como tornar o Scrum mais agradável
+
+Uma explicação melhor do Scrum ajudaria todo mundo a entender e participar melhor.
+
+## Como aumentar a qualidade do produto?
+
+- Se atentar ao padrão de código em python. Configurar as extensões de lint e formatter para os padrões utilizados
+- Remover códigos desnecessários (service e core)
+- Estudar mais os conceitos de testes de software
+- Usar TDD
+
+## Melhorias a serem implementadas no modo que o Time Scrum faz seu trabalho
+
+- Mandar dúvidas mais detalhadas
+- Utilizar os tópicos do Discord para orgnanizar as discussões e dúvidas. Sempre que uma dúvida/discussão for respondida já abrir um tópico
+- Criar as atividades no Github com todas as informações necessárias, após a reunião de planejamento
+- Utilizar as técnicas de pareamento (https://martinfowler.com/articles/on-pair-programming.html)
+
+"A implementação destas melhorias na próxima Sprint é a forma de adaptação à inspeção que o Time Scrum faz a si próprio." (SCHWABER e SUTHERLAND, 2014, p. 13).
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_3/revisao.md
+++ b/docs/scrum/sprint_3/revisao.md
@@ -1,0 +1,62 @@
+---
+title: Revisão
+---
+
+# Revisão da Sprint 3
+
+## O que ficou pronto nessa sprint?
+
+- Operação de ponderação u.u com TDD + Testes parametrizados
+- Passagem do arquivo json e do ID como argumentos via measuresoftgram import
+- Validação de métricas (NaN e nulas)
+- Definição de IDs para as pré configurações
+- Criação da pré configuração está funcionando
+- Adaptação dos pesos para valores decimais
+
+## Aspectos da sprint
+
+### Aspectos positivos
+
+- Entendemos melhor o modelo matemático
+- First time TDD
+- MVC começando a fazer sentido
+- MDSs começando a andar sozinhos
+- Melhor entedimento dos conceitos de APIs REST
+
+### Problemas / soluções
+
+- Problema em reunir com o par ou trio
+  - Trabalhar assincronamente com o par ou trio
+  - Montar os pares pensando nos horários
+- A casa caiu com o notebook e caiu na nossa cabeça
+  - Força tarefa pra entender aquelas contas
+  - Leitura do artigo de novo
+  - MUITA matemática
+  - Chamar o pai da criança
+  - Fazer as coisas do modelo passo a passo
+  - Abstrair casos menores
+- Os pesos das histórias estão ficando muito longe do real
+  - Considerar mais questões ao definir os pesos
+  - Quebrar as histórias (Talvez pensar em descer a granularidade para Tarefas)
+- Conhecimento teórico acerca das ferramentas e conceitos que estamos utilizando
+  - Estudar mais os conceitos e ferramentas do ponto de vista teórico (não apenas na prática)
+
+## O produto irá ser finalizado no prazo?
+
+Não.
+
+## O que vem a seguir?
+
+- Criar as funções de interpretação das medidas de confiabilidade
+- Operação de agregação (LET'S DO IT!)
+- Concluir a leitura das métricas
+- Implementar a melhoria de criação por arquivo JSON
+- Visualizar a pré configuração do modelo
+
+## Mudanças no backlog de produto
+
+Sem mudanças.
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_4/planejamento.md
+++ b/docs/scrum/sprint_4/planejamento.md
@@ -1,0 +1,38 @@
+---
+title: Planejamento
+---
+
+# Planejamento da Sprint 4
+
+## Qual o objetivo da Sprint?
+
+### Objetivo visão TD
+
+- Continuar entregando funcionalidade do "core" do MeasureSoftGram;
+- Acabar o que tá pendente e muito atrasado;
+- Alterar a entrada de pré-config no sistema para o padrão de arquivo .json;
+
+## Definir os pares
+
+3 Pares e um trio
+
+- Rhuan & Igor
+- Thiago & Renan
+- Lucas e Vitor
+- Ana e Marcos
+- Jeff, Samuel e Joao
+
+## Backlog da sprint
+
+- Criar as funções de interpretação das medidas de confiabilidade - Jeff, Samuel e Joao
+- Criar a pré-configuração - Jeff, Samuel e Joao (Finalizar os testes)
+- Operação de agregação (LET'S DO IT!) - Lucas e Vitor
+- Concluir a leitura das métricas, agora vai - Marcos e Ana
+- Implementar a melhoria de criação por arquivo JSON - ?
+- Visualizar a pré configuração do modelo - ?
+- Obter resultados em forma textual - Renan e Thiago
+- Selecionar as características, subcaracterísticas, medidas e pesos via interface - Rhuan e Igor
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_4/retrospectiva.md
+++ b/docs/scrum/sprint_4/retrospectiva.md
@@ -1,0 +1,60 @@
+---
+title: Retrospectiva
+---
+
+# Retrospectiva da Sprint 4
+
+"A Retrospectiva da Sprint é uma oportunidade para o Time Scrum inspecionar a si próprio e criar um plano para melhorias a serem aplicadas na próxima Sprint." (SCHWABER e SUTHERLAND, 2014, p. 12).
+
+## Visão da sprint
+
+### Em relação às pessoas
+
+- Ociosa para alguns pares
+- Difícil
+- Lenta
+- Cansativa
+
+### Em relação aos relacionamentos
+
+- Neutro
+
+### Em relação aos processos e ferramentas
+
+- Mantivemos o uso mais inteligente do Discord (utilizando os tópicos e etc)
+- Dificuldade no entendimento de API
+- Conturbada em relação ao Scrum
+
+## Itens que foram bem (ordenados)
+
+- Tópicos do discord continuaram dando certo
+- Equipe entendendo a arquitetura do sistema
+
+## Potenciais melhorias (ordenados)
+
+- Discutir mais as coisas antes da implementação
+- Criar hábito de conversar nos Pull Requests
+
+## Como tornar o Scrum mais agradável?
+
+Sem ideias.
+
+## Como aumentar a qualidade do produto?
+
+Há algo que pode ser feito para aumentar a qualidade do produto?
+
+- Analisar o notebook de qualidade e ver possíveis pontos melhorias
+
+## Melhorias a serem implementadas no modo que o Time Scrum faz seu trabalho
+
+- Mandar dúvidas mais detalhadas
+- Criar hábito de conversar nos Pull Requests
+- Criar as tarefas para as histórias no Github com todas as informações necessárias, após a reunião de planejamento
+- Utilizar as técnicas de pareamento (https://martinfowler.com/articles/on-pair-programming.html) inclusive pareamento assíncrono
+
+
+"A implementação destas melhorias na próxima Sprint é a forma de adaptação à inspeção que o Time Scrum faz a si próprio." (SCHWABER e SUTHERLAND, 2014, p. 13).
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_4/revisao.md
+++ b/docs/scrum/sprint_4/revisao.md
@@ -1,0 +1,48 @@
+---
+title: Revisão
+---
+
+# Revisão da Sprint 4
+
+## O que ficou pronto nessa sprint?
+
+- Criar a função para a medida de fast test builds
+- Criar a função para a medida de passed tests
+
+## Aspectos da sprint
+
+### Aspectos positivos
+
+- Entendimento de limitações na implementação em questão da agregação
+- Bom progresso na história de criar as pré configurações via arquivo
+- Primeira vez que utilizamos api web na de Visualização da pré configuração
+
+### Problemas / soluções
+
+- Dificuldade em entender API web
+  - Buscar entender mais as documentações
+- Falta de clareza nos critérios de aceitação
+- Falta de discussão do time sobre os critérios
+  - Discutir melhor a definição dos critérios de aceitação
+- Falta de tempo para conciliar com outras matérias
+  - Buscar um melhor conciliamentodo tempo separando duas horas diárias para a matéria
+- Falta de conhecimento, gastando bastante tempo para fazer as coisas
+  - Observar com mais calma as documentações
+
+## O produto irá ser finalizado no prazo?
+
+- Não, mesmo com a redução de escopo
+
+## O que vem a seguir?
+
+- Finalizar as pendências
+- Análises das releases utilizando a mesma pré configuração
+- Criar HU de exportar os dados brutos
+
+## Mudanças no backlog de produto
+
+- Os critérios de aceitação nas histórias foram alterados após a conclusão das mesmas
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_5/planejamento.md
+++ b/docs/scrum/sprint_5/planejamento.md
@@ -1,0 +1,32 @@
+---
+title: Planejamento
+---
+
+# Planejamento da Sprint 5
+
+## Qual o objetivo da Sprint?
+
+### Objetivo visão TD
+
+- Acabar o que tá pendente e muito atrasado
+- Tentar puxar as histórias do backlog da sprint
+
+## Definir os pares
+
+3 Pares e um trio
+
+- Rhuan & Igor
+- Thiago & Renan
+- Lucas e Vitor
+- Ana e Marcos
+- Jeff, Samuel e Joao
+
+## Backlog da sprint
+
+- Implementar a melhoria de criação por arquivo JSON - Marcos e Ana
+- Visualizar a pré configuração do modelo - Jeff, Samuel e Joao
+- Obter resultados em forma textual - Vitor e Lucas
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_5/retrospectiva.md
+++ b/docs/scrum/sprint_5/retrospectiva.md
@@ -1,0 +1,64 @@
+---
+title: Retrospectiva
+---
+
+# Retrospectiva da Sprint 5
+
+"A Retrospectiva da Sprint é uma oportunidade para o Time Scrum inspecionar a si próprio e criar um plano para melhorias a serem aplicadas na próxima Sprint." (SCHWABER e SUTHERLAND, 2014, p. 12).
+
+## Visão da sprint
+
+### Em relação às pessoas
+
+- Ociosa para alguns pares
+- Difícil
+- Lenta
+
+### Em relação aos relacionamentos
+
+- Maior parte dos pares não interagiram bem (Os horários quase não bateram)
+
+### Em relação aos processos e ferramentas
+
+- Dificuldade com git
+- Melhor uso do Discord (utilizando os tópicos e etc)
+- Melhor entendimento do Docker
+- Melhor entendimento de API
+- Melhor entendimento do Insomnia
+- A action de Linting tava habilitada só na main e PRs para a main
+
+## Itens que foram bem (ordenados)
+
+- Tópicos do discord deram muito certo
+- Equipe entendendo a arquitetura do sistema
+- Revisão dos pull requests
+
+## Potenciais melhorias (ordenados)
+
+- Criar hábito de conversar nos Pull Requests
+- Criar as discussões no Github sempre que chegar num ponto que necessite da participação de toda a equipe
+
+## Como tornar o Scrum mais agradável?
+
+Sem ideias.
+
+## Como aumentar a qualidade do produto?
+
+- Se atentar ao padrão de código em python. Configurar as extensões de lint e formatter para os padrões utilizados
+- Remover códigos desnecessários (service e core)
+- Estudar mais os conceitos de testes de software
+- Usar TDD
+
+## Melhorias a serem implementadas no modo que o Time Scrum faz seu trabalho
+
+- Mandar dúvidas mais detalhadas
+- Criar hábito de conversar nos Pull Requests
+- Criar as tarefas para as histórias no Github com todas as informações necessárias, após a reunião de planejamento
+- Utilizar as técnicas de pareamento (https://martinfowler.com/articles/on-pair-programming.html) inclusive pareamento assíncrono
+
+
+"A implementação destas melhorias na próxima Sprint é a forma de adaptação à inspeção que o Time Scrum faz a si próprio." (SCHWABER e SUTHERLAND, 2014, p. 13).
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_5/revisao.md
+++ b/docs/scrum/sprint_5/revisao.md
@@ -1,0 +1,53 @@
+---
+title: Revisão
+---
+
+# Revisão da Sprint 5
+
+## O que ficou pronto nessa sprint?
+
+- Operação de ponderação, de verdade
+- Ajustes das funções de interpretação
+- Função de interpretação de cobertura de testes (faço em 10 min assim que acabar aqui)
+
+## Aspectos da sprint
+
+### Aspectos positivos
+
+- As funções de interpretação estão bem definidas e testadas
+- Os PRs estão sendo revisados com atenção
+
+### Problemas / soluções
+
+<!-- Isso é um problema mesmo? As unicas USs que não tem tarefas nem foram tocadas -->
+- Falta de tarefas nas histórias
+  - Escrever melhor as tarefas para as histórias
+- Falta de clareza nos critérios de aceitação
+- Falta de discussão do time sobre os critérios
+  - Discutir melhor a definição dos critérios de aceitação
+- Os critérios de aceitação não ficaram prontos em tempo hábil
+  - Não tem muito o que fazer
+- Falta de tempo para conciliar com outras matérias
+  - Buscar um melhor conciliamentodo tempo separando duas horas diárias para a matéria
+- Falta de conhecimento, gastando bastante tempo para fazer as coisas
+  - Observar com mais calma as documentações
+
+## O produto irá ser finalizado no prazo?
+
+- Não, mesmo com a redução de escopo
+
+## O que vem a seguir?
+
+- Criar operação de agregação
+- Ajustes na história Criar operação de ponderação
+- Criar pré configuração via arquivo
+- Visualizar pré configuração
+- Obter resultados em forma textual
+
+## Mudanças no backlog de produto
+
+Sem mudanças.
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_6/planejamento.md
+++ b/docs/scrum/sprint_6/planejamento.md
@@ -1,0 +1,39 @@
+---
+title: Planejamento
+---
+
+# Planejamento da Sprint 6
+
+## Qual o objetivo da Sprint?
+
+### Objetivo visão TD
+
+- Continuar entregando funcionalidade do "core" do MeasureSoftGram;
+- Acabar o que tá pendente e muito atrasado;
+- Alterar a entrada de pré-config no sistema para o padrão de arquivo .json;
+
+## Definir os pares
+
+3 Pares e um trio
+
+- Rhuan & Igor
+- Thiago & Renan
+- Lucas e Vitor
+- Ana e Marcos
+- Jeff, Samuel e Joao
+
+## Backlog da sprint
+
+- Criar a pré-configuração - Após reunião
+- Leitura das métricas - Após reunião
+- Criar função de interpret. cobertura - Após reunião
+- Operação de agregação (LET'S DO IT!) - Lucas e Vitor
+- Implementar a melhoria de criação por arquivo JSON - Marcos e Ana
+- Visualizar a pré configuração do modelo - Jeff, Samuel e Joao
+- Obter resultados em forma textual - Renan e Thiago
+- Implementar operação de comparação trigonométrica - Igor e Rhuan
+
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,10 +69,17 @@ const config = {
             label: 'Contribuição',
           },
           {
+            type: 'doc',
+            docId: 'scrum/sprint_1/revisao',
+            position: 'left',
+            label: 'Scrum',
+          },
+          {
             href: 'https://github.com/fga-eps-mds/2021-2-MeasureSoftGram-Doc',
             label: 'GitHub',
             position: 'right',
           },
+
         ],
       },
       footer: {

--- a/sidebars.js
+++ b/sidebars.js
@@ -17,6 +17,14 @@ const sidebars = {
   docsSidebar: ['artifact/how_to_use', 'artifact/sad', 'artifact/low_prototype', 'artifact/high_prototype'],
   planningSidebar: ['planning/charter', 'planning/wbs', 'planning/time', 'planning/cost', 'planning/knowledge_board', 'planning/communication', 'planning/risk', 'planning/quality_attributes'],
   contributeSidebar: ['contribute/how_to_contribute', 'contribute/github_standards', 'contribute/code_of_conduct'],
+  scrumSidebar: {
+    "Sprint 1": ['scrum/sprint_1/revisao', 'scrum/sprint_1/retrospectiva'],
+    "Sprint 2": ['scrum/sprint_2/planejamento', 'scrum/sprint_2/revisao', 'scrum/sprint_2/retrospectiva'],
+    "Sprint 3": ['scrum/sprint_3/planejamento', 'scrum/sprint_3/revisao', 'scrum/sprint_3/retrospectiva'],
+    "Sprint 4": ['scrum/sprint_4/planejamento', 'scrum/sprint_4/revisao', 'scrum/sprint_4/retrospectiva'],
+    "Sprint 5": ['scrum/sprint_5/planejamento', 'scrum/sprint_5/revisao', 'scrum/sprint_5/retrospectiva'],
+    "Sprint 6": ['scrum/sprint_6/planejamento']
+  }
 };
 
 module.exports = sidebars;


### PR DESCRIPTION
# Adiciona documentos dos eventos Scrum

## Descrição
Este PR tem como objetivo adicionar os documentos referentes aos eventos Scrum das sprints realizadas durante a disciplina

[Documentar as "atas" dos eventos Scrum](https://github.com/fga-eps-mds/2021-2-MeasureSoftGram-Doc/issues/183)

## Porque este Pull Request é necessário?
Para integrar os documentos ao repositório

## Critérios de aceitação
(Exemplos de critérios de aceitação)

1. [x] Todas as informações necessárias estão presentes?
2. [x] O documento está escrito de forma concisa?
3. [x] A ortografia do documento está correta?

Closes #183
