### PR TITLE
Adiciona o restante da documentação Scrum

### DIFF
--- a/docs/scrum/sprint_5/revisao.md
+++ b/docs/scrum/sprint_5/revisao.md
@@ -28,7 +28,7 @@ title: Revisão
 - Os critérios de aceitação não ficaram prontos em tempo hábil
   - Não tem muito o que fazer
 - Falta de tempo para conciliar com outras matérias
-  - Buscar um melhor conciliamentodo tempo separando duas horas diárias para a matéria
+  - Buscar um melhor conciliamento do tempo separando duas horas diárias para a matéria
 - Falta de conhecimento, gastando bastante tempo para fazer as coisas
   - Observar com mais calma as documentações
 
@@ -46,7 +46,16 @@ title: Revisão
 
 ## Mudanças no backlog de produto
 
-Sem mudanças.
+Foram despriorizadas:
+- Implementar operação de comparação trigonométrica
+
+Foram priorizadas:
+- Análises das releases utilizando a mesma pré configuração
+
+Foram merjadas:
+- Implementar operação de agregragação
+- Implementar operação de ponderação
+- Realizar análise
 
 ## Referências
 

--- a/docs/scrum/sprint_6/planejamento.md
+++ b/docs/scrum/sprint_6/planejamento.md
@@ -24,15 +24,10 @@ title: Planejamento
 
 ## Backlog da sprint
 
-- Criar a pré-configuração - Após reunião
-- Leitura das métricas - Após reunião
-- Criar função de interpret. cobertura - Após reunião
 - Operação de agregação (LET'S DO IT!) - Lucas e Vitor
 - Implementar a melhoria de criação por arquivo JSON - Marcos e Ana
 - Visualizar a pré configuração do modelo - Jeff, Samuel e Joao
-- Obter resultados em forma textual - Renan e Thiago
-- Implementar operação de comparação trigonométrica - Igor e Rhuan
-
+- Realizar o cálculo (ponderação, agregação) e obter os resultados em forma textual - Vitor, Lucas, Rhuan e Thiago
 
 ## Referências
 

--- a/docs/scrum/sprint_6/retrospectiva.md
+++ b/docs/scrum/sprint_6/retrospectiva.md
@@ -1,0 +1,58 @@
+---
+title: Retrospectiva
+---
+
+# Retrospectiva da Sprint 6
+
+"A Retrospectiva da Sprint é uma oportunidade para o Time Scrum inspecionar a si próprio e criar um plano para melhorias a serem aplicadas na próxima Sprint." (SCHWABER e SUTHERLAND, 2014, p. 12).
+
+## Visão da sprint
+
+### Em relação às pessoas
+
+- Corrida
+- Quebrada no meio da apresentação
+
+### Em relação aos relacionamentos
+
+- Usamos o máximo de nossas habilidades comunicativas para ajudar a resolver o problema
+    - Spoiler: não deu tão certo
+
+### Em relação aos processos e ferramentas
+
+- Falta de atenção na hora de gerar release
+- Falta de atenção na hora de fazer o merge das branches (cuidado com conflitos)
+
+## Itens que foram bem (ordenados)
+
+- Conseguimos terminar, melhora o alto astral
+- Segunda sprint que conseguimos finalizar tudo o que tínhamos proposto
+
+## Potenciais melhorias (ordenados)
+
+- Olhar os comentários nos PRs
+- Automatizar atualização do pacote do CLI na geração de release
+- Automatizar dependências do pacote do CLI em relação à configuração de teste
+
+## Como tornar o Scrum mais agradável?
+
+Sem ideias.
+
+## Como aumentar a qualidade do produto?
+
+- Corrigir as pendências dos PRs
+- Realizar uma nova análise de qualidade e definindo problemas e possíveis pontos de melhoria
+
+## Melhorias a serem implementadas no modo que o Time Scrum faz seu trabalho
+
+- Code Harder
+- Code Better
+- Code Faster
+- Code Stronger
+
+
+"A implementação destas melhorias na próxima Sprint é a forma de adaptação à inspeção que o Time Scrum faz a si próprio." (SCHWABER e SUTHERLAND, 2014, p. 13).
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_6/revisao.md
+++ b/docs/scrum/sprint_6/revisao.md
@@ -1,0 +1,45 @@
+---
+title: Revisão
+---
+
+# Revisão da Sprint 6
+
+## O que ficou pronto nessa Sprint?
+
+- **TUDO** da sprint
+
+## Aspectos da sprint
+
+### Aspectos positivos
+
+- As funções de interpretação estão bem definidas e testadas
+- Os PRs estão sendo revisados com atenção
+- MVP meio capenga finalizado
+- Aprendizado em API
+
+### Problemas / soluções
+
+- Correção errada de conflitos ao dar merge nas histórias
+  - Resolver com antecedência e com mais cuidado
+- Conflito sobre trabalho possível/realizado e novas funcionalidades requeridas
+  - Observar a prioridade constantemente
+- Tempo para realizar correções nos PRs
+  - Resolver com antecedência
+
+## O produto irá ser finalizado no prazo?
+
+- Sim, mas meio capenga e com alguns critérios não validados e corrigidos
+
+## O que vem a seguir?
+
+- Análises das releases utilizando a mesma pré configuração
+- Correções referentes aos testes de aceitação
+
+## Mudanças no backlog de produto
+
+Só algumas priorizações:
+- Análises das releases utilizando a mesma pré configuração
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_7/planejamento.md
+++ b/docs/scrum/sprint_7/planejamento.md
@@ -1,0 +1,29 @@
+---
+title: Planejamento
+---
+
+# Planejamento da Sprint 7
+
+## Qual o objetivo da Sprint?
+
+### Objetivo visão TD
+
+- Arrumar os pontos comentados nos PRs da sprint passada
+- Implementar a funcionalidade de análise de várias releases de um mesmo software
+
+## Definir os pares
+
+1 Par e um grupo
+
+- Vitor e Ana => salvar o nome do arquivo de métricas e exibi-lo no list e show
+- Todo mundo
+
+Cada indivíduo das duplas deverá corrigir os comentários de seus PRs.
+
+## Backlog da sprint
+
+- Análises das releases utilizando a mesma pré configuração (todos)
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_7/retrospectiva.md
+++ b/docs/scrum/sprint_7/retrospectiva.md
@@ -1,0 +1,58 @@
+---
+title: Retrospectiva
+---
+
+# Retrospectiva da Sprint 7
+
+"A Retrospectiva da Sprint é uma oportunidade para o Time Scrum inspecionar a si próprio e criar um plano para melhorias a serem aplicadas na próxima Sprint." (SCHWABER e SUTHERLAND, 2014, p. 12).
+
+## Visão da sprint
+
+### Em relação às pessoas
+
+- Corrida
+- Quebrada no meio da apresentação
+
+### Em relação aos relacionamentos
+
+- Usamos o máximo de nossas habilidades comunicativas para ajudar a resolver o problema
+    - Spoiler: não deu tão certo
+
+### Em relação aos processos e ferramentas
+
+- Falta de atenção na hora de gerar release
+- Falta de atenção na hora de fazer o merge das branches (cuidado com conflitos)
+
+## Itens que foram bem (ordenados)
+
+- Conseguimos terminar, melhora o alto astral
+- Segunda sprint que conseguimos finalizar tudo o que tínhamos proposto
+
+## Potenciais melhorias (ordenados)
+
+- Olhar os comentários nos PRs
+- Automatizar atualização do pacote do CLI na geração de release
+- Automatizar dependências do pacote do CLI em relação à configuração de teste
+
+## Como tornar o Scrum mais agradável?
+
+Sem ideias.
+
+## Como aumentar a qualidade do produto?
+
+- Corrigir as pendências dos PRs
+- Realizar uma nova análise de qualidade e definindo problemas e possíveis pontos de melhoria
+
+## Melhorias a serem implementadas no modo que o Time Scrum faz seu trabalho
+
+- Work it Harder
+- Make it Better
+- Do it Faster
+- Makes us Stronger
+
+
+"A implementação destas melhorias na próxima Sprint é a forma de adaptação à inspeção que o Time Scrum faz a si próprio." (SCHWABER e SUTHERLAND, 2014, p. 13).
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/docs/scrum/sprint_7/revisao.md
+++ b/docs/scrum/sprint_7/revisao.md
@@ -1,0 +1,45 @@
+---
+title: Revisão
+---
+
+# Revisão da Sprint 7
+
+## O que ficou pronto nessa Sprint?
+
+- **TUDO** da sprint
+
+## Aspectos da sprint
+
+### Aspectos positivos
+
+- As funções de interpretação estão bem definidas e testadas
+- Os PRs estão sendo revisados com atenção
+- MVP meio capenga finalizado
+- Aprendizado em API
+
+### Problemas / soluções
+
+- Correção errada de conflitos ao dar merge nas histórias
+  - Resolver com antecedência e com mais cuidado
+- Conflito sobre trabalho possível/realizado e novas funcionalidades requeridas
+  - Observar a prioridade constantemente
+- Tempo para realizar correções nos PRs
+  - Resolver com antecedência
+
+## O produto irá ser finalizado no prazo?
+
+- Sim, mas meio capenga e com alguns critérios não validados e corrigidos
+
+## O que vem a seguir?
+
+- Análises das releases utilizando a mesma pré configuração
+- Correções referentes aos testes de aceitação
+
+## Mudanças no backlog de produto
+
+Só algumas priorizações:
+- Análises das releases utilizando a mesma pré configuração
+
+## Referências
+
+> SCHWABER, Ken; SUTHERLAND, Jeff. “Guia do Scrum - Um guia definitivo para o Scrum: As regras do jogo”. Scrum.Org and ScrumInc, 2014.

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,7 +23,8 @@ const sidebars = {
     "Sprint 3": ['scrum/sprint_3/planejamento', 'scrum/sprint_3/revisao', 'scrum/sprint_3/retrospectiva'],
     "Sprint 4": ['scrum/sprint_4/planejamento', 'scrum/sprint_4/revisao', 'scrum/sprint_4/retrospectiva'],
     "Sprint 5": ['scrum/sprint_5/planejamento', 'scrum/sprint_5/revisao', 'scrum/sprint_5/retrospectiva'],
-    "Sprint 6": ['scrum/sprint_6/planejamento']
+    "Sprint 6": ['scrum/sprint_6/planejamento', 'scrum/sprint_6/revisao', 'scrum/sprint_6/retrospectiva'],
+    "Sprint 7": ['scrum/sprint_7/planejamento', 'scrum/sprint_7/revisao', 'scrum/sprint_7/retrospectiva']
   }
 };
 


### PR DESCRIPTION
# Adiciona o restante da documentação Scrum

## Descrição
Adiciona documentos referentes às Sprints 6 e 7, além de ajustes no documento de revisão da Sprint 5.

[Documentar as "atas" dos eventos Scrum](https://github.com/fga-eps-mds/2021-2-MeasureSoftGram-Doc/issues/183)

## Porque este Pull Request é necessário?
Para que a documentação Scrum esteja por completo na Wiki do projeto

## Critérios de aceitação
(Exemplos de critérios de aceitação)

1. [x] Todas as informações necessárias estão presentes?
2. [x] O documento está escrito de forma concisa?
3. [x] A ortografia do documento está correta?

Closes #183

